### PR TITLE
编译luci-app-mosdns apk

### DIFF
--- a/Scripts/Packages.sh
+++ b/Scripts/Packages.sh
@@ -31,6 +31,7 @@ UPDATE_PACKAGE "ssr-plus" "fw876/helloworld" "master"
 
 UPDATE_PACKAGE "alist" "sbwml/luci-app-alist" "main"
 UPDATE_PACKAGE "mosdns" "sbwml/luci-app-mosdns" "v5"
+UPDATE_PACKAGE "luci-app-mosdns" "sbwml/luci-app-mosdns" "v5"
 UPDATE_PACKAGE "wol" "VIKINGYFY/packages" "main" "pkg"
 
 UPDATE_PACKAGE "luci-app-gecoosac" "lwb1978/openwrt-gecoosac" "main"


### PR DESCRIPTION
你好 大佬 我是之前提交过云编译分配Ubuntu24版本编译问题的那个
最近想用mosdns发现大佬已经添加了Package 编译出来
选择在软件包进行安装时找不到界面插件 官方的一键脚本还停留在ipk
