### PR TITLE
fix(WRT_INFO): variable definition

### DIFF
--- a/.github/workflows/WRT-CORE.yml
+++ b/.github/workflows/WRT-CORE.yml
@@ -97,7 +97,8 @@ jobs:
         run: |
           echo "WRT_DATE=$(TZ=UTC-8 date +"%y.%m.%d-%H.%M.%S")" >> $GITHUB_ENV
           echo "WRT_MARK=${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV
-          echo "WRT_INFO=${WRT_SOURCE%%/*}" >> $GITHUB_ENV
+          WRT_INFO="${WRT_SOURCE%%/*}"
+          echo "WRT_INFO=$WRT_INFO" >> $GITHUB_ENV
           echo "WRT_TARGET=$(grep -m 1 -oP '^CONFIG_TARGET_\K[\w]+(?=\=y)' ./Config/$WRT_CONFIG.txt)" >> $GITHUB_ENV
           WRT_CACHE_ARCH=$(awk -F= '
             /^CONFIG_TARGET_[^=]+=y$/ {


### PR DESCRIPTION
In the same step, the $WRT_INFO in the later code [ echo "WRT_LEGACY_CACHE_PREFIX=$WRT_CONFIG-$WRT_INFO" >> $GITHUB_ENV ] will never be initialized.